### PR TITLE
fix: the action error of oryx callback on_publish event example

### DIFF
--- a/i18n/en-us/docusaurus-plugin-content-docs/current/doc/getting-started-oryx.md
+++ b/i18n/en-us/docusaurus-plugin-content-docs/current/doc/getting-started-oryx.md
@@ -295,7 +295,7 @@ For HTTP callback `on_publish` event:
 Request:
 {
   "request_id": "3ab26a09-59b0-42f7-98e3-a281c7d0712b",
-  "action": "on_unpublish",
+  "action": "on_publish",
   "opaque": "mytoken",
   "vhost": "__defaultVhost__",
   "app": "live",

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/doc/getting-started-oryx.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/doc/getting-started-oryx.md
@@ -275,7 +275,7 @@ For HTTP callback `on_publish` event:
 Request:
 {
   "request_id": "3ab26a09-59b0-42f7-98e3-a281c7d0712b",
-  "action": "on_unpublish",
+  "action": "on_publish",
   "opaque": "mytoken",
   "vhost": "__defaultVhost__",
   "app": "live",

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/version-5.0/doc/getting-started-oryx.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/version-5.0/doc/getting-started-oryx.md
@@ -276,7 +276,7 @@ For HTTP callback `on_publish` event:
 Request:
 {
   "request_id": "3ab26a09-59b0-42f7-98e3-a281c7d0712b",
-  "action": "on_unpublish",
+  "action": "on_publish",
   "opaque": "mytoken",
   "vhost": "__defaultVhost__",
   "app": "live",

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/version-6.0/doc/getting-started-oryx.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/version-6.0/doc/getting-started-oryx.md
@@ -275,7 +275,7 @@ For HTTP callback `on_publish` event:
 Request:
 {
   "request_id": "3ab26a09-59b0-42f7-98e3-a281c7d0712b",
-  "action": "on_unpublish",
+  "action": "on_publish",
   "opaque": "mytoken",
   "vhost": "__defaultVhost__",
   "app": "live",

--- a/versioned_docs/version-5.0/doc/getting-started-oryx.md
+++ b/versioned_docs/version-5.0/doc/getting-started-oryx.md
@@ -290,7 +290,7 @@ For HTTP callback `on_publish` event:
 Request:
 {
   "request_id": "3ab26a09-59b0-42f7-98e3-a281c7d0712b",
-  "action": "on_unpublish",
+  "action": "on_publish",
   "opaque": "mytoken",
   "vhost": "__defaultVhost__",
   "app": "live",

--- a/versioned_docs/version-6.0/doc/getting-started-oryx.md
+++ b/versioned_docs/version-6.0/doc/getting-started-oryx.md
@@ -295,7 +295,7 @@ For HTTP callback `on_publish` event:
 Request:
 {
   "request_id": "3ab26a09-59b0-42f7-98e3-a281c7d0712b",
-  "action": "on_unpublish",
+  "action": "on_publish",
   "opaque": "mytoken",
   "vhost": "__defaultVhost__",
   "app": "live",


### PR DESCRIPTION
### HTTP Callback: on_publish

For HTTP callback `on_publish` event:

```json
Request:
{
  "request_id": "3ab26a09-59b0-42f7-98e3-a281c7d0712b",
  "action": "on_unpublish",// fix to on_publish
  "opaque": "mytoken",
  "vhost": "__defaultVhost__",
  "app": "live",
  "stream": "livestream",
  "param": "?secret=8f7605d657c74d69b6b48f532c469bc9"
}
