### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -270,6 +270,7 @@ const config = {
   },
   plugins: [
     ...regionConfig.plugins,
+    'docusaurus-plugin-copy-page-button',
     [
       './config/docusaurus-rewrite-siteconfig-plugin',
       {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@docusaurus/theme-classic": "^3.1.1",
     "@mdx-js/react": "^3.0.1",
     "clsx": "^1.1.1",
+    "docusaurus-plugin-copy-page-button": "^0.4.2",
     "mdx-mermaid": "^2.0.0",
     "mermaid": "^10.8.0",
     "prism-react-renderer": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@docusaurus/theme-classic": "^3.1.1",
     "@mdx-js/react": "^3.0.1",
     "clsx": "^1.1.1",
-    "docusaurus-plugin-copy-page-button": "^0.4.2",
+    "docusaurus-plugin-copy-page-button": "^0.5.2",
     "mdx-mermaid": "^2.0.0",
     "mermaid": "^10.8.0",
     "prism-react-renderer": "^2.1.0",


### PR DESCRIPTION
## What this adds

A "Copy page" button in the docs sidebar that exports the current SRS docs page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions.

## Why for SRS

SRS users wrangling streaming pipelines (RTMP/SRT/WebRTC, transcoders, low-latency tuning) hit AI tools constantly while building configs and debugging. There's already a placeholder for an AI assistant link in the navbar (currently commented out in `docusaurus.config.js`), so the project clearly cares about AI-friendly docs. This plugin gives users a one-click handoff from any docs page into their AI tool of choice.

## Production users

The plugin is currently shipping on Ethereum execution-apis, Sui (Mysten Labs), Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, Chronicle, Cardano, Kurtosis, and Dagger docs. ~10k npm installs/month.

## Changes

- Adds `docusaurus-plugin-copy-page-button` to `dependencies`
- Adds the plugin string to the `plugins` array in `docusaurus.config.js`

The button auto-injects into the table-of-contents sidebar. No further config required, theme-aware, mobile-friendly.

## Links

- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/
- Plugin repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button

Happy to revert or adjust if this doesn't fit the project's direction.